### PR TITLE
Fix: Update "Каталоги ТЕП" button to link to "Товари" page

### DIFF
--- a/src/components/Home/MoreOffers/MoreOffers.tsx
+++ b/src/components/Home/MoreOffers/MoreOffers.tsx
@@ -26,7 +26,7 @@ export function MoreOffers() {
               bg={IMG1}
             />
             <InfoCard
-              url={MainUrl.getSales()}
+              url={MainUrl.getGoods()}
               title={"Каталоги ТЕП"}
               description={
                 "В нашому магазині можна придбати товари за акційною пропозицією..."


### PR DESCRIPTION
Task description: 
-В «Більше пропозицій» на головні сторінці, кнопка «Каталоги ТЕП» має вести на сторінку «Товари»: https://tep-store.vercel.app/goods

Changes:
-Updated the Link of the "Каталоги ТЕП" button to link to the "Товари" page.