### PR TITLE
[THT-114] Buyer Info page: "services" hyperlink is not working, should be broken down into subcategories and lead to specific pages

### DIFF
--- a/src/app/information-for-buyers/_data.tsx
+++ b/src/app/information-for-buyers/_data.tsx
@@ -2,10 +2,6 @@ import { InfoUrl, MainUrl, ServicesUrl } from "route-urls";
 
 export const info_links = [
   {
-    title: "Послуги",
-    url: MainUrl.getServices(),
-  },
-  {
     title: "Зв’яжись з нами",
     url: InfoUrl.getContactUs(),
   },
@@ -37,4 +33,19 @@ export const info_links = [
     title: "Політика конфіденційності",
     url: MainUrl.getPrivacyPolicy(),
   },
+];
+
+export const servicesLinks = [
+  {
+    title: "Відстежити замовлення",
+    url: ServicesUrl.getTracking(),
+  },
+  {
+    title: "Послуги доставки",
+    url: ServicesUrl.getDelivery(),
+  },
+  {
+    title: "Подарункові картки",
+    url: ServicesUrl.getGifts(),
+  }
 ];

--- a/src/app/information-for-buyers/page.tsx
+++ b/src/app/information-for-buyers/page.tsx
@@ -1,12 +1,15 @@
 import Link from "next/link";
 import { FiArrowRight } from "react-icons/fi";
 
-import { Disclosure } from "common/Disclosure";
+import { Disclosure, DisclosureItem } from "common/Disclosure";
 import { Container, Section, Title } from "common/ui";
 
-import { info_links } from "./_data";
+import { info_links, servicesLinks } from "./_data";
+import { useId } from "react";
 
 export default function InformationForBuyersPage() {
+  const id = useId();
+
   return (
     <Section>
       <Container>
@@ -24,6 +27,25 @@ export default function InformationForBuyersPage() {
             демократичним дизайном своїх виробів.
           </p>
           <Disclosure>
+            <DisclosureItem
+                key={id}
+                trigger={
+                  <Title component={"h4"} size={"xl"}>
+                    {"Послуги"}
+                  </Title>
+                }
+              >
+                <ul className={"flex flex-col gap-y-[18px]"}>
+                  {servicesLinks.map((i, indx) => 
+                    <li key={indx}>
+                      <Link href={i.url} className={
+                        "underline-offset-[3px] transition-colors hover:text-tep_blue-500 hover:underline"
+                      }>{i.title}
+                      </Link>
+                    </li>
+                  )}
+                </ul>
+              </DisclosureItem>
             {info_links.map((link) => (
               <Link
                 href={link.url}


### PR DESCRIPTION
[THT-114] Buyer Info page: "services" hyperlink is not working, should be broken down into subcategories and lead to specific pages